### PR TITLE
Visual Studio crash fix

### DIFF
--- a/SassyStudio.2013/Editor/CompileScssOnSave.cs
+++ b/SassyStudio.2013/Editor/CompileScssOnSave.cs
@@ -81,8 +81,17 @@ namespace SassyStudio.Editor
             var project = sourceProjectItem.ContainingProject;
             foreach (var projectItem in VisitProjectItems(project.ProjectItems))
             {
-                var path = (string)projectItem.Properties.Item("FullPath").Value;
-                var filename = Path.GetFileName(path);
+                string path;
+                try
+                {
+                    path = (string)projectItem.Properties.Item("FullPath").Value;
+                }
+                catch (ArgumentException)
+                {
+                    continue;
+                }
+
+                var  filename = Path.GetFileName(path);
 
                 // ignore anything that isn't .scss and not a root document
                 if (filename.EndsWith(".scss", StringComparison.OrdinalIgnoreCase) && !filename.StartsWith("_"))


### PR DESCRIPTION
EnvDTE.Properties.Item() throws an exception if the specified value could not be found in the properties collection (https://msdn.microsoft.com/en-us/library/envdte.properties.item.aspx). This has to be handled otherwise in this case, Visual Studio crashes.