### PR TITLE
Fixed invalid stale file detection

### DIFF
--- a/SassyStudio.2013/Editor/CompileScssOnSave.cs
+++ b/SassyStudio.2013/Editor/CompileScssOnSave.cs
@@ -130,7 +130,7 @@ namespace SassyStudio.Editor
 
             var source = new FileInfo(path);
             // file is stale, likely another request coming in
-            if (time < source.LastWriteTime)
+            if (time.ToLocalTime() < source.LastWriteTime)
             {
                 if (Options.IsDebugLoggingEnabled)
                     Logger.Log("Ignoring compile due to stale document.");


### PR DESCRIPTION
Fixed invalid stale file detection on the right (plus) side of UTC time.
time is a Utc time, source.LastWriteTime is a Local time. This was fixed.